### PR TITLE
Introduce admin port parameter to differentiate the admin client connection and general client connection RFC

### DIFF
--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -17,7 +17,8 @@ We want to let adminstrator connect to this admin port to do some special things
 
 Beside above mentioned, we could implement the following features in the future:
 1. The connections through admin port are not limited to maxclient number, we can always guarantee they can connect to the server.
-2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first
+2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first, such as:
+   PING, HELLO, ECHO, INFO etc
 
 
 ## Design Considerations

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -9,23 +9,20 @@ Status: Proposed
 
 In Valkey.conf, Add a new config parameter: "admin-port" to allow cloud providers or internal administrators in a company or special users from public internet to connect to the Valkey server to execute some special commands or load specfic modules.
 
-
 ## Motivation
 
-For adminstrators, they may want to execute some special commands in the server, which are usually defined in the module, and
-other general clients are not allowed to run these kinds of commands. Thus connecting to an admin-port is a good way to implement this feature. 
+For adminstrators, they may want to execute some special commands for system administration in the server, such as authentication or traffic control commands, which are usually defined in the module. And other general clients are not allowed to run these kinds of commands. Thus connecting to an admin-port is a good way to implement this feature. 
 
-Beside above mentioned, we could implement the following features in the future once admin-port is commited:
+Beside above mentioned, we could implement the following enhancement features in the future once admin-port is commited:
 1. The connections through admin port are not limited to maxclient number, we can always guarantee the administrators can connect to the server.
-2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first, such as: PING, HELLO, ECHO, INFO etc
-
+2. Some status check commands or dangerous commands could be sent and received through admin port, we can do some special logic to make sure they have opportunity to be handle first, such as: PING, HELLO, ECHO, INFO, FLUSHALL etc
 
 ## Design Considerations
 
 Before we propose the "admin-port" feature, we have the following 3 candidates:
-1. ACL: Now Valkey have ACL feature to implement similar function, but it brings one disadvantages: username need to be predefined.
+1. ACL: Now Valkey have ACL feature to implement similar function, but it brings two disadvantages: firstly, username need to be predefined and secondly, total number of client connections can not exceed the maxclient. Once the emergence issue happens and maxclient number reaches, the privilege user can not connect to the server any more.
 
-2. Run some special commands through the connected IP address: Before we run every commands, we need check if the client ip address is in a linkedlist, it costs CPU and extra memory, it causes side effect in performance
+2. Run some special customize commands for system administration through the connected IP address: Before we run every commands, we need check if the client ip address is in a linkedlist, it costs CPU and extra memory, it causes side effect in performance
 
 3. Iptables: It works on transport layer and IP address, but it can not apply to the specific commands of the Valkey
 
@@ -35,8 +32,10 @@ Based on all above 3 candidate defects, we decide to select "admin-port" to impl
 ## Specification
 
 1. The admin client role is only decided by the cloud providers or internal administrators, whatever where the client comes from. Thus generally, admin-port should not be exposed to the public.
-2. If a client connects via admin-port and ACL rules apply to this client as well, this client should follow the ACL to execute some commands
-3. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands. The special commands could be new commands introduced by admin through modules, for example, setting/getting traffic/replication control threshold, encrypting the username and password in config file, etc
+2. For every module, there is the API RedisModule_CreateCommand which defines a function to execute your customize command. You can find a way to decide if the command can be called by the client.
+3. For those Valkey built-in commands, generally we do not consider Valkey built-in commands as the special commands. Of course, now we can consider FLUSHALL command as an exception.
+4. If a client connects via admin-port and ACL rules apply to this client as well, this client should follow the ACL to execute some commands
+5. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands. The special commands could be new commands introduced by admin through modules, for example, setting/getting traffic/replication control threshold, encrypting the username and password in config file, etc
 
 ## References
 Add a management-port https://github.com/valkey-io/valkey/issues/497

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -1,0 +1,52 @@
+---
+RFC: 1
+Status: Informational
+---
+
+Valkey RFC
+==========
+
+This repository is a collection of feature proposals and descriptions of changes to Valkey
+that require some more detail than just the text in a pull request or an issue.
+It is loosely inspired by RFCs and by Python's enhancement proposals (PEP).
+
+Each feature or larger topic is described in a markdown file that's named in
+uppercase and ends in `.md`. These files are not formally numbered, but we use
+the pull request number that initially added an RFC to refer to the change. For example,
+this description in the README.md file was written in RFC #1.
+
+Workflow
+--------
+
+An RFC starts off as a pull request. It's reviewed for formatting, style,
+consisteny and content quality. The content shouldn't be very vague or unclear.
+Then the proposal is merged. This doesn't mean that the feature is approved for
+inclusion in Valkey. It's still just a proposal.
+
+Each file has one of the following statuses:
+
+* **Proposed**, meaning the file was added but there's no decision about it yet.
+* **Approved**, meaning the core team has made a decision to accept the feature.
+* **Rejected**, meaning the core team has made a decision to not accpt the feature.
+* **Informational**, for information that is not a feature, like this README file.
+
+The core team (the Technical Steering Committee) can change the status and make
+changes. For larger changes, the PR making the change is mentioned too and can
+be referred to by their respective pull-request numbers.
+
+What's useful to include?
+-------------------------
+
+The Valkey RFC format is not a strict format, but should include the following
+sections unless they are unnecessary for the proposal you are submitting.
+
+* Status and RFC number (the pull-request number).
+* Abstract. A few sentences describing the feature.
+* Motivation. What the feature solves and why the existing functionality is not
+  enough.
+* Design considerations. A description of the design constraints and
+  requirements for the proposal. Comparisons with similar features in other
+  projects.
+* Specification. A more detailed description of the feature, including why
+  certain details in the design have been chosen.
+* Links to related material such as issues, pull requests, papers, or other references.

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -7,18 +7,17 @@ Status: Proposed
 
 ## Abstract
 
-In Valkey.conf, Add a new config parameter: "admin-port" to allow internal administrators in a company or special users from public internet to connect to the Valkey server to execute some special commands or load specfic modules.
+In Valkey.conf, Add a new config parameter: "admin-port" to allow cloud providers or internal administrators in a company or special users from public internet to connect to the Valkey server to execute some special commands or load specfic modules.
 
 
 ## Motivation
 
-For adminstrators, they may want to execute some special commands in the server, and other general clients are not allowed to run these kinds of commands.
-We want to let adminstrator connect to this admin port to do some special things. 
+For adminstrators, they may want to execute some special commands in the server, which are usually defined in the module, and
+other general clients are not allowed to run these kinds of commands. Thus connecting to an admin-port is a good way to implement this feature. 
 
-Beside above mentioned, we could implement the following features in the future:
-1. The connections through admin port are not limited to maxclient number, we can always guarantee they can connect to the server.
-2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first, such as:
-   PING, HELLO, ECHO, INFO etc
+Beside above mentioned, we could implement the following features in the future once admin-port is commited:
+1. The connections through admin port are not limited to maxclient number, we can always guarantee the administrators can connect to the server.
+2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first, such as: PING, HELLO, ECHO, INFO etc
 
 
 ## Design Considerations
@@ -26,16 +25,18 @@ Beside above mentioned, we could implement the following features in the future:
 Before we propose the "admin-port" feature, we have the following 3 candidates:
 1. ACL: Now Valkey have ACL feature to implement similar function, but it brings one disadvantages: username need to be predefined.
 
-2. Run some special commands through the connected IP address: Before we run every commands, we need check if the client ip address is in a linkedlist, it costs
-                                                               CPU and extra memory, it causes side effect in performance
+2. Run some special commands through the connected IP address: Before we run every commands, we need check if the client ip address is in a linkedlist, it costs CPU and extra memory, it causes side effect in performance
 
 3. Iptables: It works on transport layer and IP address, but it can not apply to the specific commands of the Valkey
 
 Based on all above 3 candidate defects, we decide to select "admin-port" to implement our goal.
 
 
-## Specification 
+## Specification
 
+1. The admin client role is only decided by the cloud provides or internal administrators, whatever where the client comes from. Thus generally, admin-port should not be exposed to public.
+2. If a client connects via admin-port and ACL rules apply to this client as well, this client should follow the ACL to execute some commands
+3. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands.
 
 ## References
 Add a management-port https://github.com/valkey-io/valkey/issues/497

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -34,9 +34,9 @@ Based on all above 3 candidate defects, we decide to select "admin-port" to impl
 
 ## Specification
 
-1. The admin client role is only decided by the cloud provides or internal administrators, whatever where the client comes from. Thus generally, admin-port should not be exposed to public.
+1. The admin client role is only decided by the cloud providers or internal administrators, whatever where the client comes from. Thus generally, admin-port should not be exposed to the public.
 2. If a client connects via admin-port and ACL rules apply to this client as well, this client should follow the ACL to execute some commands
-3. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands.
+3. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands. The special commands could be new commands introduced by admin through modules, for example, setting/getting traffic/replication control threshold, encrypting the username and password in config file, etc
 
 ## References
 Add a management-port https://github.com/valkey-io/valkey/issues/497

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -32,7 +32,7 @@ Based on all above 3 candidate defects, we decide to select "admin-port" to impl
 ## Specification
 
 1. The admin client role is only decided by the cloud providers or internal administrators, whatever where the client comes from. Thus generally, admin-port should not be exposed to the public.
-2. For every module, there is the API RedisModule_CreateCommand which defines a function to execute your customize command. You can find a way to decide if the command can be called by the client.
+2. For every module, there is the API RedisModule_CreateCommand which defines a function to execute your customize command. You can find a way to to get the port number that client connects to the server and then to decide if the command can be called by the client.
 3. For those Valkey built-in commands, generally we do not consider Valkey built-in commands as the special commands. Of course, now we can consider FLUSHALL command as an exception.
 4. If a client connects via admin-port and ACL rules apply to this client as well, this client should follow the ACL to execute some commands
 5. If a client connects via non-admin-port and ACL rules apply to this client as well, this client is not allowed to execute those special commands. The special commands could be new commands introduced by admin through modules, for example, setting/getting traffic/replication control threshold, encrypting the username and password in config file, etc

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -1,12 +1,44 @@
-ADMIN PORT
-==========
-Reference the issue https://github.com/valkey-io/valkey/issues/497 (add a management-port) and https://github.com/valkey-io/valkey/issues/469 (Trusted/un-trusted client feature)
+---
+RFC: 3
+Status: Proposed
+---
 
-Background: In some cases, we can run valkey server on a container and multiply containers could be run in a physical machine simultaneously.
-            Adminstator wants to execute some special commands in the server, and general clients are not allowed to run these kinds of commands.
-            Thus, we want to set an admin port for adminstator connection, and general clients could still connect with server with port argument.
+# ADMIN PORT RFC
 
-            Although Valkey invloved ACL concept, but we need to set user first. But for this case, we have no idea the admin clients name and general 
-            clients name as well. Thus The better solution is that let admin clients and general clients connect to 2 different port of server.
+## Abstract
 
-            We can introduce another parameter in valkey.conf:  admin-port
+In Valkey.conf, Add a new config parameter: "admin-port" to allow internal administrators in a company or special users from public internet to connect to the Valkey server to execute some special commands or load specfic modules.
+
+
+## Motivation
+
+For adminstrators, they may want to execute some special commands in the server, and other general clients are not allowed to run these kinds of commands.
+We want to let adminstrator connect to this admin port to do some special things. 
+
+Beside above mentioned, we could implement the following features in the future:
+1. The connections through admin port are not limited to maxclient number, we can always guarantee they can connect to the server.
+2. Some status check commands could be sent and receied through admin port, we can do some special logic to make sure they have opportunity to be handle first
+
+
+## Design Considerations
+
+Before we propose the "admin-port" feature, we have the following 3 candidates:
+1. ACL: Now Valkey have ACL feature to implement similar function, but it brings one disadvantages: username need to be predefined.
+
+2. Run some special commands through the connected IP address: Before we run every commands, we need check if the client ip address is in a linkedlist, it costs
+                                                               CPU and extra memory, it causes side effect in performance
+
+3. Iptables: It works on transport layer and IP address, but it can not apply to the specific commands of the Valkey
+
+Based on all above 3 candidate defects, we decide to select "admin-port" to implement our goal.
+
+
+## Specification 
+
+
+## References
+Add a management-port https://github.com/valkey-io/valkey/issues/497
+Trusted/un-trusted client feature https://github.com/valkey-io/valkey/issues/469, https://github.com/valkey-io/valkey/pull/666
+iptables — a comprehensive guide https://sudamtm.medium.com/iptables-a-comprehensive-guide-276b8604eff1
+An In-Depth Guide to iptables, the Linux Firewall https://www.booleanworld.com/depth-guide-iptables-linux-firewall/
+

--- a/ADMIN-PORT.md
+++ b/ADMIN-PORT.md
@@ -1,52 +1,12 @@
----
-RFC: 1
-Status: Informational
----
-
-Valkey RFC
+ADMIN PORT
 ==========
+Reference the issue https://github.com/valkey-io/valkey/issues/497 (add a management-port) and https://github.com/valkey-io/valkey/issues/469 (Trusted/un-trusted client feature)
 
-This repository is a collection of feature proposals and descriptions of changes to Valkey
-that require some more detail than just the text in a pull request or an issue.
-It is loosely inspired by RFCs and by Python's enhancement proposals (PEP).
+Background: In some cases, we can run valkey server on a container and multiply containers could be run in a physical machine simultaneously.
+            Adminstator wants to execute some special commands in the server, and general clients are not allowed to run these kinds of commands.
+            Thus, we want to set an admin port for adminstator connection, and general clients could still connect with server with port argument.
 
-Each feature or larger topic is described in a markdown file that's named in
-uppercase and ends in `.md`. These files are not formally numbered, but we use
-the pull request number that initially added an RFC to refer to the change. For example,
-this description in the README.md file was written in RFC #1.
+            Although Valkey invloved ACL concept, but we need to set user first. But for this case, we have no idea the admin clients name and general 
+            clients name as well. Thus The better solution is that let admin clients and general clients connect to 2 different port of server.
 
-Workflow
---------
-
-An RFC starts off as a pull request. It's reviewed for formatting, style,
-consisteny and content quality. The content shouldn't be very vague or unclear.
-Then the proposal is merged. This doesn't mean that the feature is approved for
-inclusion in Valkey. It's still just a proposal.
-
-Each file has one of the following statuses:
-
-* **Proposed**, meaning the file was added but there's no decision about it yet.
-* **Approved**, meaning the core team has made a decision to accept the feature.
-* **Rejected**, meaning the core team has made a decision to not accpt the feature.
-* **Informational**, for information that is not a feature, like this README file.
-
-The core team (the Technical Steering Committee) can change the status and make
-changes. For larger changes, the PR making the change is mentioned too and can
-be referred to by their respective pull-request numbers.
-
-What's useful to include?
--------------------------
-
-The Valkey RFC format is not a strict format, but should include the following
-sections unless they are unnecessary for the proposal you are submitting.
-
-* Status and RFC number (the pull-request number).
-* Abstract. A few sentences describing the feature.
-* Motivation. What the feature solves and why the existing functionality is not
-  enough.
-* Design considerations. A description of the design constraints and
-  requirements for the proposal. Comparisons with similar features in other
-  projects.
-* Specification. A more detailed description of the feature, including why
-  certain details in the design have been chosen.
-* Links to related material such as issues, pull requests, papers, or other references.
+            We can introduce another parameter in valkey.conf:  admin-port


### PR DESCRIPTION
I would like to introduce another parameter in valkey.conf:  admin-port

Background:

The parameter "maxclient" default value is 10000. Client administrators could set higher value to accept more client connection.
However, there is one situation: If the connection number of client reaches the maxclient, then even administrators have no chance to connect to the server to process some urgent issues or update some configurations.

To solve above case, by connecting to the admin port, an administrator or cloud provider has the chance to connect to the server even the max number of connected clients reaches
